### PR TITLE
remove/add packages for RHEL6/7 installations

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,8 +3,6 @@ db2_packages:
  - pam
  - pam-devel.i686
  - libaio
- - compat-libstdc++-33.i686
- - compat-libstdc++-33
  - libstdc++-devel.i686
  - libstdc++
  - ksh

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,3 +10,4 @@ db2_packages:
  - ksh
  - unzip
  - numactl
+ - libselinux-python

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -9,3 +9,4 @@ db2_packages:
  - libstdc++
  - ksh
  - unzip
+ - numactl


### PR DESCRIPTION
Hi Bernando,

Thank you for role for DB2! It saved me a lot of time when testing cluster setups.

After testing installation of DB2 10.5 and 11.1 on 'minimal installation' RHEL 6.9 and 7.4 I have found some missing packages and also some not needed packages (due to which the role was failing in RHEL 7.4). Below is playbook I have used for testing the installation (including only one for DB 10.5 but for 11.1 it was identical except of 'location' and 'db2_creates' variables).

    ---
    - hosts: all
      remote_user: root
      vars:
        db2_binary:
          location: '/root/DB2_Svr_10.5.0.1_Linux_x86-64.tar.gz'
          dest: /tmp
        db2_creates: 'server'
        resp:
          prod: 'DB2_SERVER_EDITION'
          file: '/opt/ibm/db2/V10.5'
          lic_agreement: "ACCEPT"
          install_type: "TYPICAL"
      roles:
        - { role: 'ansible-role-db2' }

By 'minimal installation' of RHEL I mean systems that were installed using following kickstarts.
https://github.com/OndrejHome/fast-vm-public-images/blob/master/rhel/ks/rhel-6.ks
https://github.com/OndrejHome/fast-vm-public-images/blob/master/rhel/ks/rhel-7.1.ks

I was not testing the changes beyond the installation using the above playbook. After all changes I'm able to do installations without errors.

Would it be possible to include these changes and push them to Ansible galaxy?

Ondrej