### PR TITLE
Fixed warnings in 'when'-statements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,10 @@
     tags: download
 
   - include: packages-redhat.yml
-    when: "'{{ansible_os_family}}' == 'RedHat'"
+    when: ansible_os_family == "RedHat"
 
   - include: packages-debian.yml
-    when: "'{{ansible_os_family}}' == 'Debian'"
+    when: ansible_os_family == "Debian"
 
   - include: instance_users.yml
     tags: ['users', 'setup']
@@ -18,7 +18,7 @@
   - name: Disabling SELinux
     selinux: state=disabled
     tags: ['dont-on-docker', 'setup']
-    when: "'{{ansible_os_family}}' == 'RedHat'"
+    when: ansible_os_family == "RedHat"
 
   - name: Adding entry to /etc/hosts
     lineinfile:


### PR DESCRIPTION
Removed jinja delimiters in when statements.
This is to get rid of warnings like this one:
  [WARNING]: when statements should not include jinja2 templating delimiters
  such as {{ }} or {% %}. Found: '{{ansible_os_family}}' == 'Debian'