### PR TITLE
allow disabling instance creation and home directory creation (for cluster deployments)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,27 +10,45 @@ before_install:
   - 'sudo docker build --rm=true --file=tests/Dockerfile --tag=ol7-db2:latest tests'
 
 script:
-  # Prepare tests
+  ### [1] - test DB2 installation with instance and DB creation + do syntax check of full_example.yml
+  # [1] Prepare tests
   - container_id=$(mktemp)
 
-    # Run container in detached state
+  # [1] Run container in detached state
   - 'sudo docker run --privileged=true --detach --volume="${PWD}":/etc/ansible/roles/db2 ol7-db2:latest "/sbin/init" > "${container_id}"'
 
-  # Syntax under docker 
+  # [1] Syntax under docker
   - 'sudo docker exec --tty "$(cat ${container_id})" env ansible-playbook /etc/ansible/roles/db2/examples/full_example.yml --syntax-check'
 
-  # Check if it downloaded the binary
+  # [1] Check if it downloaded the binary
   - 'sudo docker exec --tty "$(cat ${container_id})" env ls /tmp/db2.tar.gz'
 
-  # Run playbook
+  # [1] Run playbook
   - 'travis_wait sudo docker exec --tty "$(cat ${container_id})" env ansible-playbook /etc/ansible/roles/db2/examples/docker_test.yml --skip-tags dont-on-docker'
 
-  # Test role idempotence.
+  # [1] Test role idempotence.
   - >
     travis_wait sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/db2/examples/docker_test.yml --skip-tags dont-on-docker
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
 
-  # Clean up
+  # [1] Clean up
+  - 'sudo docker stop "$(cat ${container_id})"'
+
+  ### [2] - test DB2 installation  without creating instances and databases
+  # [2] Run container in detached state
+  - 'sudo docker run --privileged=true --detach --volume="${PWD}":/etc/ansible/roles/db2 ol7-db2:latest "/sbin/init" > "${container_id}"'
+
+  # [2] Run playbook
+  - 'travis_wait sudo docker exec --tty "$(cat ${container_id})" env ansible-playbook /etc/ansible/roles/db2/examples/docker_test_without_instances.yml --skip-tags dont-on-docker'
+
+  # [2] Test role idempotence.
+  - >
+    travis_wait sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/db2/examples/docker_test_without_instances.yml --skip-tags dont-on-docker
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
+  # [2] Clean up
   - 'sudo docker stop "$(cat ${container_id})"'

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ You need at least specify where to get DB2. [Downloading db2](https://github.com
           location: /ansible/files/db2_10.5.tar.gz
            dest: /tmp
 
+###Installing DB2 without instances
+
+In some cases, such as cluster failover deployment, you may wish to install only DB2 software and not create any instances.
+This can be achieved by specifying the `create_instances: false` variable like shown below.
+
+    vars:
+      create_instances: false
+
+The full example [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/db2_without_instances.yml)
+
 ###Creating a custom instance
 
 The instance will be created using all DB2 defaults, but you can customize it using the hash **db2_instances**
@@ -111,7 +121,7 @@ The full example [here](https://github.com/bernardoVale/ansible-role-db2/tree/ma
            fenced_username: "myfenc1"
            fenced_group_name: "myfadm1"
            
-**db2_instances** is a list of instances, yo can create more than one, an example of two instances is found [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/multiples_instances.yml)
+**db2_instances** is a list of instances, you can create more than one, an example of two instances is found [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/multiples_instances.yml)
 
 ###Customizing Parameters
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,6 @@ db2_instances:
     fenced_username: "db2fenc1"
     fenced_group_name: "db2fadm1"
 
- # Create the instances listed in 'db2_instances' variable.
- # This can be set to false for installation without any instance.
- create_instances: true
+# Create the instances listed in 'db2_instances' variable.
+# This can be set to false for installation without any instance.
+create_instances: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,7 @@ db2_instances:
     group_name: "db2iadm1"
     fenced_username: "db2fenc1"
     fenced_group_name: "db2fadm1"
+
+ # Create the instances listed in 'db2_instances' variable.
+ # This can be set to false for installation without any instance.
+ create_instances: true

--- a/examples/db2_without_instances.yml
+++ b/examples/db2_without_instances.yml
@@ -1,0 +1,42 @@
+---
+#In this example we are installing DB2 without instances, so just installing the DB2 software.
+  - hosts: all
+    gather_facts: True
+    pre_tasks:
+      # This is required to test on RedHat (No license on vagrant)
+      - name: Installing OL Public repository
+        get_url: 
+          url: "{{yum_repo}}"
+          dest: /etc/yum.repos.d/public-yum-release.repo
+        tags: download
+    roles:
+      - db2
+    vars:
+      # this variable tells to NOT create any DB2 instances 
+      create_instances: false
+      # If the db2_instances are specified together with 'create_instances: false',
+      # then still the specified users and groups are created by this role.
+      # The DB2 instances will NOT be created.
+      # This can be useful for cluster deployment to ensure that uids/gids match across cluster.
+      db2_instances:
+        - instance: "DB2INST"
+          name: "myinstan" 
+          group_name: "myinadm"
+          fenced_username: "myfenc1"
+          fenced_group_name: "myfadm1"
+          #Password:
+          #Optionally set the user's password to this crypted value. See the user example in the
+          #github examples directory for what this looks like in a playbook.
+          #See http://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module
+          #for details on various ways to generate these password values. Note on Darwin system,
+          #this value has to be cleartext. Beware of security issues.
+          password: "oracle"
+          fenced_password: "anotherpass"
+          # Read (Instance specifications) on the website above to get a list of all optionals parameters related to a DB2 instance:
+          # https://www-01.ibm.com/support/knowledgecenter/SSEPGG_10.5.0/com.ibm.db2.luw.qb.server.doc/doc/r0007505.html
+          uid: 999
+          gid: 987
+          fenced_uid: 888
+          fenced_gid: 876
+          # do not create home directories for normal and fence user
+          createhome: false

--- a/examples/docker_test_without_instances.yml
+++ b/examples/docker_test_without_instances.yml
@@ -1,0 +1,39 @@
+---
+# This is to test on Docker
+  - hosts: all
+    gather_facts: True
+    pre_tasks:
+
+      - name: Create /DB2 directory
+        file:
+          path: /db2
+          state: directory
+          mode: 0755
+        tags: users
+
+    roles:
+      - db2
+    vars:
+       # don't create DB2 instances
+       # but still create instance users and groups without home directories
+      create_instances: false
+       # Define the db2_binary and setup the URL to download.
+       # Variable location define where should put db2 on ansible machine
+       # Variable dest define where should decompress DB2 on remote host
+      db2_binary:
+        location: "/tmp/db2.tar.gz"
+        dest: "/tmp"
+
+      db2_instances:
+        - instance: "DB2INST"
+          name: "db2inst"
+          group_name: "db2iadm"
+          fenced_username: "db2fenc"
+          fenced_group_name: "db2fadm"
+          home_directory: "/db2/db2inst"
+          fenced_home_directory: "/db2/db2fenc"
+          uid: 901
+          gid: 902
+          fenced_uid: 801
+          fenced_gid: 802
+          createhome: false

--- a/tasks/instance_users.yml
+++ b/tasks/instance_users.yml
@@ -23,7 +23,7 @@
     password: "{{ item.password | default('ldUMKEu7/QCAY')}}"
     home: "{{ item.home_directory | default(omit) }}"
     uid: "{{ item.uid | default(omit) }}"
-    createhome: "{{ item.createhome | default(omit) }}"
+    createhome: "{{ item.createhome | default(true) }}"
   with_items: "{{ db2_instances }}"
 
 - name: Creating DB2 Fenced Users
@@ -33,6 +33,6 @@
     password: "{{ item.fenced_password | default('ldUMKEu7/QCAY')}}"
     home: "{{ item.fenced_home_directory | default(omit) }}"
     uid: "{{ item.fenced_uid | default(omit) }}"
-    createhome: "{{ item.createhome | default(omit) }}"
+    createhome: "{{ item.createhome | default(true) }}"
   with_items: "{{ db2_instances }}"
   register: db2_fenced_user

--- a/tasks/instance_users.yml
+++ b/tasks/instance_users.yml
@@ -23,6 +23,7 @@
     password: "{{ item.password | default('ldUMKEu7/QCAY')}}"
     home: "{{ item.home_directory | default(omit) }}"
     uid: "{{ item.uid | default(omit) }}"
+    createhome: "{{ item.createhome | default(omit) }}"
   with_items: "{{ db2_instances }}"
 
 - name: Creating DB2 Fenced Users
@@ -32,5 +33,6 @@
     password: "{{ item.fenced_password | default('ldUMKEu7/QCAY')}}"
     home: "{{ item.fenced_home_directory | default(omit) }}"
     uid: "{{ item.fenced_uid | default(omit) }}"
+    createhome: "{{ item.createhome | default(omit) }}"
   with_items: "{{ db2_instances }}"
   register: db2_fenced_user

--- a/templates/db2server.j2.rsp
+++ b/templates/db2server.j2.rsp
@@ -25,6 +25,7 @@ INSTALL_TYPE              = {{resp.install_type}}
 
 {%for inst in db2_instances %}
 
+{%if create_instances == true %}
 ** Instance Creation Settings
 ** --------------------------
 INSTANCE                  = {{inst.instance}}
@@ -47,6 +48,7 @@ INSTANCE                  = {{inst.instance}}
 {% for key, value in inst.dbm_params.iteritems() %}
 {{inst.instance | upper}}.{{ key | upper}}             = {{ value }}
 {% endfor %}
+{% endif %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Hi @bernardoVale,

I would like the role to just install DB2 without creating instances and also with creating users but without creating their home directories. This is for the use case where this is installed on new cluster node where DB2 will need to have same users, but everything else is provided on shared storage. The things on shared storage (home directories and instance data) should be created only once.
In this PR is proposal on how to achieve the above.

If the changes are OK, I would prepare a separate playbook that will install DB without instance, with some customized users that will not create the home directories so this can be tested. However it would require a separate docker instance as the proposed changes cannot be tested with already existing one.

Please let me know if this would be OK and also if you have any additional requirements for including this changes.